### PR TITLE
Add route scoped provider health

### DIFF
--- a/src/mgp/protocol.js
+++ b/src/mgp/protocol.js
@@ -1,9 +1,13 @@
-export function createMgpRoutePacket(request, rankedProviders) {
+export function createMgpRoutePacket(request, rankedProviders, routeScope = null) {
     const url = new URL(request.url);
+    const requestId = crypto.randomUUID();
+    const routeKey = routeScope?.routeKey || "route:" + normalizeRoutePath(url.pathname);
 
     return {
         protocol: "mgp-edge-v1",
-        routeId: crypto.randomUUID(),
+        routeId: requestId,
+        requestId: requestId,
+        routeKey: routeKey,
         method: request.method,
         path: url.pathname,
         createdAt: Date.now(),
@@ -53,4 +57,15 @@ function normalizeAssetPath(value) {
     }
 
     return "/" + value;
+}
+
+function normalizeRoutePath(path) {
+    const normalizedPath = normalizeAssetPath(path);
+    const slashIndex = normalizedPath.lastIndexOf("/");
+
+    if (slashIndex <= 0) {
+        return "/";
+    }
+
+    return normalizedPath.slice(0, slashIndex);
 }

--- a/src/routing/health.js
+++ b/src/routing/health.js
@@ -1,29 +1,40 @@
 const HEALTH = new Map();
 const FAILURE_TTL_MS = 30000;
+const GLOBAL_SCOPE_KEY = "global";
 
-export function getHealthSnapshot() {
+export function getHealthSnapshot(scopeKey = GLOBAL_SCOPE_KEY) {
     const now = Date.now();
     const output = {};
 
-    for (const [name, state] of HEALTH.entries()) {
-        output[name] = {
-            successes: state.successes,
-            failures: state.failures,
-            lastLatencyMs: state.lastLatencyMs,
-            avgLatencyMs: state.avgLatencyMs,
-            blockedUntil: Math.max(0, state.blockedUntil - now),
-            lastError: state.lastError || null
-        };
+    for (const [key, state] of HEALTH.entries()) {
+        const parsed = parseHealthKey(key);
+
+        if (parsed.scopeKey !== scopeKey) {
+            continue;
+        }
+
+        output[parsed.providerName] = createSnapshotState(state, now);
     }
 
     return output;
 }
 
-export function markProviderSuccess(name, latencyMs) {
-    const state = getState(name);
+export function getLayeredHealthSnapshot(layers) {
+    return layers.map(layer => ({
+        scopeKey: layer.scopeKey,
+        weight: normalizeWeight(layer.weight),
+        providers: getHealthSnapshot(layer.scopeKey)
+    }));
+}
+
+export function markProviderSuccess(scopeKeyOrName, nameOrLatencyMs, maybeLatencyMs) {
+    const input = normalizeMutationInput(scopeKeyOrName, nameOrLatencyMs, maybeLatencyMs);
+    const state = getState(input.scopeKey, input.providerName);
+    const latencyMs = Number(input.value);
+
     state.successes += 1;
-    state.lastLatencyMs = latencyMs;
-    state.avgLatencyMs = state.avgLatencyMs === 0 ? latencyMs : Math.round(state.avgLatencyMs * 0.75 + latencyMs * 0.25);
+    state.lastLatencyMs = Number.isFinite(latencyMs) === true ? latencyMs : 0;
+    state.avgLatencyMs = state.avgLatencyMs === 0 ? state.lastLatencyMs : Math.round(state.avgLatencyMs * 0.75 + state.lastLatencyMs * 0.25);
     state.lastError = null;
 
     if (state.failures > 0) {
@@ -31,12 +42,15 @@ export function markProviderSuccess(name, latencyMs) {
     }
 }
 
-export function markProviderFailure(name, reason) {
-    const state = getState(name);
+export function markProviderFailure(scopeKeyOrName, nameOrReason, maybeReason) {
+    const input = normalizeMutationInput(scopeKeyOrName, nameOrReason, maybeReason);
+    const state = getState(input.scopeKey, input.providerName);
+    const reason = String(input.value || "fetch-error");
+
     state.failures += 1;
     state.lastError = reason;
 
-    if (state.failures >= 2 || String(reason).startsWith("blocked-")) {
+    if (state.failures >= 2 || reason.startsWith("blocked-")) {
         state.blockedUntil = Date.now() + FAILURE_TTL_MS;
     }
 }
@@ -45,8 +59,20 @@ export function resetHealthState() {
     HEALTH.clear();
 }
 
-function getState(name) {
-    let state = HEALTH.get(name);
+function createSnapshotState(state, now) {
+    return {
+        successes: state.successes,
+        failures: state.failures,
+        lastLatencyMs: state.lastLatencyMs,
+        avgLatencyMs: state.avgLatencyMs,
+        blockedUntil: Math.max(0, state.blockedUntil - now),
+        lastError: state.lastError || null
+    };
+}
+
+function getState(scopeKey, providerName) {
+    const key = createHealthKey(scopeKey, providerName);
+    let state = HEALTH.get(key);
 
     if (state === undefined) {
         state = {
@@ -57,8 +83,62 @@ function getState(name) {
             blockedUntil: 0,
             lastError: null
         };
-        HEALTH.set(name, state);
+        HEALTH.set(key, state);
     }
 
     return state;
+}
+
+function createHealthKey(scopeKey, providerName) {
+    return normalizeScopeKey(scopeKey) + "|" + providerName;
+}
+
+function parseHealthKey(key) {
+    const index = key.lastIndexOf("|");
+
+    if (index < 0) {
+        return {
+            scopeKey: GLOBAL_SCOPE_KEY,
+            providerName: key
+        };
+    }
+
+    return {
+        scopeKey: key.slice(0, index),
+        providerName: key.slice(index + 1)
+    };
+}
+
+function normalizeMutationInput(first, second, third) {
+    if (third === undefined) {
+        return {
+            scopeKey: GLOBAL_SCOPE_KEY,
+            providerName: String(first),
+            value: second
+        };
+    }
+
+    return {
+        scopeKey: normalizeScopeKey(first),
+        providerName: String(second),
+        value: third
+    };
+}
+
+function normalizeScopeKey(value) {
+    if (typeof value !== "string" || value.length === 0) {
+        return GLOBAL_SCOPE_KEY;
+    }
+
+    return value;
+}
+
+function normalizeWeight(value) {
+    const parsed = Number(value);
+
+    if (Number.isFinite(parsed) === false || parsed <= 0) {
+        return 1;
+    }
+
+    return parsed;
 }

--- a/src/routing/routeScope.js
+++ b/src/routing/routeScope.js
@@ -1,0 +1,67 @@
+export function createRouteScope(request) {
+    const url = new URL(request.url);
+    const path = normalizePath(url.pathname);
+    const routePath = createRoutePath(path);
+    const sessionId = normalizeScopePart(request.headers.get("x-flareless-session-id") || url.searchParams.get("session"));
+
+    const scope = {
+        path: path,
+        routePath: routePath,
+        routeKey: "route:" + routePath,
+        chunkKey: "chunk:" + path,
+        sessionKey: sessionId.length > 0 ? "session:" + sessionId : null
+    };
+
+    return scope;
+}
+
+export function createHealthLayers(routeScope) {
+    const layers = [
+        { scopeKey: "global", weight: 0.1 },
+        { scopeKey: routeScope.routeKey, weight: 1 },
+        { scopeKey: routeScope.chunkKey, weight: 2 }
+    ];
+
+    if (routeScope.sessionKey !== null) {
+        layers.push({ scopeKey: routeScope.sessionKey, weight: 3 });
+    }
+
+    return layers;
+}
+
+function normalizePath(path) {
+    if (typeof path !== "string" || path.length === 0) {
+        return "/";
+    }
+
+    if (path.startsWith("/") === false) {
+        return "/" + path;
+    }
+
+    return path;
+}
+
+function createRoutePath(path) {
+    if (path === "/") {
+        return "/";
+    }
+
+    const slashIndex = path.lastIndexOf("/");
+
+    if (slashIndex <= 0) {
+        return "/";
+    }
+
+    return path.slice(0, slashIndex);
+}
+
+function normalizeScopePart(value) {
+    if (typeof value !== "string") {
+        return "";
+    }
+
+    return value
+        .toLowerCase()
+        .replace(/[^a-z0-9_.:/]/g, "_")
+        .slice(0, 128);
+}

--- a/src/routing/selector.js
+++ b/src/routing/selector.js
@@ -1,28 +1,61 @@
 export function selectProviders(providers, healthSnapshot) {
-    const now = Date.now();
+    const healthLayers = normalizeHealthLayers(healthSnapshot);
 
     return providers
         .filter(provider => provider.enabled === true)
         .map(provider => ({
             provider: provider,
-            score: scoreProvider(provider, healthSnapshot?.[provider.name], now)
+            score: scoreProvider(provider, healthLayers)
         }))
         .sort((left, right) => left.score - right.score)
         .map(entry => entry.provider);
 }
 
-function scoreProvider(provider, health, now) {
+function scoreProvider(provider, healthLayers) {
     const priorityScore = (provider.priority || 100) * 100;
     const costScore = (provider.costWeight || 1) * 25;
+    let healthScore = 0;
 
-    if (health === undefined) {
-        return priorityScore + costScore;
+    for (const layer of healthLayers) {
+        healthScore += scoreHealth(layer.providers[provider.name], layer.weight);
     }
 
-    const blockedPenalty = health.blockedUntil > 0 ? 100000 : 0;
-    const failurePenalty = (health.failures || 0) * 500;
-    const latencyPenalty = health.avgLatencyMs || health.lastLatencyMs || 0;
-    const successBonus = Math.min((health.successes || 0) * 10, 200);
+    return priorityScore + costScore + healthScore;
+}
 
-    return priorityScore + costScore + blockedPenalty + failurePenalty + latencyPenalty - successBonus;
+function scoreHealth(health, weight) {
+    if (health === undefined) {
+        return 0;
+    }
+
+    const blockedPenalty = health.blockedUntil > 0 ? 100000 * weight : 0;
+    const failurePenalty = (health.failures || 0) * 500 * weight;
+    const latencyPenalty = (health.avgLatencyMs || health.lastLatencyMs || 0) * weight;
+    const successBonus = Math.min((health.successes || 0) * 10 * weight, 200 * weight);
+
+    return blockedPenalty + failurePenalty + latencyPenalty - successBonus;
+}
+
+function normalizeHealthLayers(healthSnapshot) {
+    if (Array.isArray(healthSnapshot) === true) {
+        return healthSnapshot.map(layer => ({
+            providers: layer.providers || {},
+            weight: normalizeWeight(layer.weight)
+        }));
+    }
+
+    return [{
+        providers: healthSnapshot || {},
+        weight: 1
+    }];
+}
+
+function normalizeWeight(value) {
+    const parsed = Number(value);
+
+    if (Number.isFinite(parsed) === false || parsed <= 0) {
+        return 1;
+    }
+
+    return parsed;
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -2,7 +2,8 @@ import { PROVIDERS } from "./config/providers.js";
 import { createMgpManifest, createMgpProviderSnapshot, createMgpRoutePacket } from "./mgp/protocol.js";
 import { selectProviders } from "./routing/selector.js";
 import { fetchThroughProvider } from "./routing/providerFetch.js";
-import { getHealthSnapshot, markProviderFailure, markProviderSuccess } from "./routing/health.js";
+import { getHealthSnapshot, getLayeredHealthSnapshot, markProviderFailure, markProviderSuccess } from "./routing/health.js";
+import { createHealthLayers, createRouteScope } from "./routing/routeScope.js";
 import { createPeerFallbackResponse } from "./peer/peerFallback.js";
 import { resolveSignalRoomName, createRoomInfo } from "./peer/roomPartition.js";
 import { MgpSignalRoom } from "./peer/signalingObject.js";
@@ -51,8 +52,10 @@ export default {
 
 async function routeRequest(request) {
     const startedAt = Date.now();
-    const rankedProviders = selectProviders(PROVIDERS, getHealthSnapshot());
-    const routePacket = createMgpRoutePacket(request, rankedProviders);
+    const routeScope = createRouteScope(request);
+    const healthLayers = createHealthLayers(routeScope);
+    const rankedProviders = selectProviders(PROVIDERS, getLayeredHealthSnapshot(healthLayers));
+    const routePacket = createMgpRoutePacket(request, rankedProviders, routeScope);
     const attempts = [];
 
     for (const provider of rankedProviders) {
@@ -63,7 +66,7 @@ async function routeRequest(request) {
                 provider: provider.name,
                 result: fetchResult.reason
             });
-            markProviderFailure(provider.name, normalizeFailureReason(fetchResult.reason));
+            markProviderFailureForScopes(routeScope, provider.name, normalizeFailureReason(fetchResult.reason));
             continue;
         }
 
@@ -74,7 +77,7 @@ async function routeRequest(request) {
                 provider: provider.name,
                 result: "PROVIDER_BLOCKED_" + response.status
             });
-            markProviderFailure(provider.name, "blocked-" + response.status);
+            markProviderFailureForScopes(routeScope, provider.name, "blocked-" + response.status);
             continue;
         }
 
@@ -82,13 +85,15 @@ async function routeRequest(request) {
             provider: provider.name,
             result: "PROVIDER_SUCCESS"
         });
-        markProviderSuccess(provider.name, Date.now() - startedAt);
+        markProviderSuccessForScopes(routeScope, provider.name, Date.now() - startedAt);
 
         const headers = new Headers(response.headers);
         headers.set("x-open-edge-provider", provider.name);
-        headers.set("x-mgp-route-id", routePacket.routeId);
+        headers.set("x-mgp-route-id", routePacket.requestId);
         headers.set("x-flareless-provider", provider.name);
-        headers.set("x-flareless-route-id", routePacket.routeId);
+        headers.set("x-flareless-route-id", routePacket.requestId);
+        headers.set("x-flareless-route-key", routePacket.routeKey);
+        headers.set("x-flareless-request-id", routePacket.requestId);
         headers.set("x-flareless-reason", createRouteReason(attempts));
         headers.set("x-flareless-attempts", createAttemptHeader(attempts));
 
@@ -101,6 +106,16 @@ async function routeRequest(request) {
     }
 
     return null;
+}
+
+function markProviderFailureForScopes(routeScope, providerName, reason) {
+    markProviderFailure(routeScope.routeKey, providerName, reason);
+    markProviderFailure(routeScope.chunkKey, providerName, reason);
+}
+
+function markProviderSuccessForScopes(routeScope, providerName, latencyMs) {
+    markProviderSuccess(routeScope.routeKey, providerName, latencyMs);
+    markProviderSuccess(routeScope.chunkKey, providerName, latencyMs);
 }
 
 function normalizeFailureReason(reason) {

--- a/tests/worker-routes.test.mjs
+++ b/tests/worker-routes.test.mjs
@@ -93,6 +93,8 @@ test("successful CDN route returns provider headers", async () => {
         assert.equal(response.headers.get("x-open-edge-provider"), "cdn-a");
         assert.ok(response.headers.get("x-mgp-route-id"));
         assert.equal(response.headers.get("x-flareless-provider"), "cdn-a");
+        assert.equal(response.headers.get("x-flareless-route-key"), "route:/video");
+        assert.ok(response.headers.get("x-flareless-request-id"));
         assert.equal(response.headers.get("x-flareless-reason"), "PRIMARY_PROVIDER_SUCCESS");
         assert.equal(response.headers.get("x-flareless-attempts"), "cdn-a:PROVIDER_SUCCESS");
     } finally {
@@ -126,6 +128,64 @@ test("blocked first provider falls through to second provider with route explana
         assert.equal(response.headers.get("x-flareless-attempts"), "cdn-a:PROVIDER_BLOCKED_451,cdn-b:PROVIDER_SUCCESS");
         assert.ok(urls.some(url => url.includes("cdn-a.example.com")));
         assert.ok(urls.some(url => url.includes("cdn-b.example.com")));
+    } finally {
+        globalThis.fetch = oldFetch;
+    }
+});
+
+test("route scoped health keeps unrelated routes on primary provider", async () => {
+    const oldFetch = globalThis.fetch;
+    const firstRouteUrls = [];
+    const sameRouteUrls = [];
+    const unrelatedRouteUrls = [];
+    let phase = "first-route";
+
+    globalThis.fetch = async function(request) {
+        if (phase === "first-route") {
+            firstRouteUrls.push(request.url);
+        }
+
+        if (phase === "same-route") {
+            sameRouteUrls.push(request.url);
+        }
+
+        if (phase === "unrelated-route") {
+            unrelatedRouteUrls.push(request.url);
+        }
+
+        if (request.url.includes("cdn-a") && request.url.includes("/video/show-a/v1/")) {
+            return new Response("blocked", { status: 451 });
+        }
+
+        return new Response("ok", { status: 200 });
+    };
+
+    try {
+        const firstRouteResponse = await worker.fetch(jsonRequest("/video/show-a/v1/chunk-0001.m4s"), makeEnv(), {});
+        await firstRouteResponse.text();
+
+        assert.equal(firstRouteResponse.headers.get("x-flareless-provider"), "cdn-b");
+        assert.equal(firstRouteResponse.headers.get("x-flareless-route-key"), "route:/video/show-a/v1");
+        assert.equal(firstRouteUrls[0], "https://cdn-a.example.com/video/show-a/v1/chunk-0001.m4s");
+        assert.equal(firstRouteUrls[1], "https://cdn-b.example.com/video/show-a/v1/chunk-0001.m4s");
+
+        phase = "same-route";
+
+        const sameRouteResponse = await worker.fetch(jsonRequest("/video/show-a/v1/chunk-0002.m4s"), makeEnv(), {});
+        await sameRouteResponse.text();
+
+        assert.equal(sameRouteResponse.headers.get("x-flareless-provider"), "cdn-b");
+        assert.equal(sameRouteResponse.headers.get("x-flareless-route-key"), "route:/video/show-a/v1");
+        assert.equal(sameRouteUrls[0], "https://cdn-b.example.com/video/show-a/v1/chunk-0002.m4s");
+
+        phase = "unrelated-route";
+
+        const unrelatedRouteResponse = await worker.fetch(jsonRequest("/assets/logo.png"), makeEnv(), {});
+        await unrelatedRouteResponse.text();
+
+        assert.equal(unrelatedRouteResponse.headers.get("x-flareless-provider"), "cdn-a");
+        assert.equal(unrelatedRouteResponse.headers.get("x-flareless-route-key"), "route:/assets");
+        assert.equal(unrelatedRouteUrls[0], "https://cdn-a.example.com/assets/logo.png");
     } finally {
         globalThis.fetch = oldFetch;
     }


### PR DESCRIPTION
## Summary

Adds route scoped provider health so a provider failure on one content route does not automatically poison unrelated routes.

## What changed

- Added route scope generation for route keys, chunk keys, and optional session keys.
- Refactored provider health storage to support scoped health keys.
- Updated provider selection to score layered health signals.
- Updated worker routing to mark route and chunk health instead of globally poisoning all traffic.
- Split stable route key from per request id in route packets and response headers.
- Added a test proving a failure on one video route moves that route to CDN B while an unrelated asset still starts on CDN A.

## Validation

The added test covers the exact routing concern:

1. CDN A fails for `/video/show-a/v1/chunk-0001.m4s`.
2. The same route group starts on CDN B for the next chunk.
3. `/assets/logo.png` still starts on CDN A.

This makes route independence real in the health model, not only in the fetch loop.