### PR TITLE
Add route policy objects

### DIFF
--- a/src/config/routePolicies.js
+++ b/src/config/routePolicies.js
@@ -1,0 +1,67 @@
+const DEFAULT_ROUTE_POLICY = {
+    id: "default-public-static",
+    pathPrefix: "/",
+    providerNames: null,
+    allowPeerFallback: true,
+    allowOriginFallback: false,
+    providerTimeoutMs: null,
+    healthScope: "route"
+};
+
+const ROUTE_POLICIES = [
+    {
+        id: "video-public-peer-first",
+        pathPrefix: "/video/",
+        providerNames: null,
+        allowPeerFallback: true,
+        allowOriginFallback: false,
+        providerTimeoutMs: null,
+        healthScope: "route"
+    },
+    {
+        id: "private-no-fallback",
+        pathPrefix: "/private/",
+        providerNames: null,
+        allowPeerFallback: false,
+        allowOriginFallback: false,
+        providerTimeoutMs: null,
+        healthScope: "route"
+    },
+    {
+        id: "origin-fallback-allowed",
+        pathPrefix: "/origin-allowed/",
+        providerNames: null,
+        allowPeerFallback: false,
+        allowOriginFallback: true,
+        providerTimeoutMs: null,
+        healthScope: "route"
+    }
+];
+
+export function resolveRoutePolicy(routeScope) {
+    const path = routeScope?.path || "/";
+    const selectedPolicy = ROUTE_POLICIES
+        .filter(policy => path.startsWith(policy.pathPrefix))
+        .sort((left, right) => right.pathPrefix.length - left.pathPrefix.length)[0] || DEFAULT_ROUTE_POLICY;
+
+    return {
+        id: selectedPolicy.id,
+        routeKey: routeScope?.routeKey || "route:/",
+        pathPrefix: selectedPolicy.pathPrefix,
+        providerNames: selectedPolicy.providerNames,
+        allowPeerFallback: selectedPolicy.allowPeerFallback === true,
+        allowOriginFallback: selectedPolicy.allowOriginFallback === true,
+        providerTimeoutMs: selectedPolicy.providerTimeoutMs,
+        healthScope: selectedPolicy.healthScope || "route"
+    };
+}
+
+export function applyRoutePolicyToProviders(providers, routePolicy) {
+    if (Array.isArray(routePolicy.providerNames) === false || routePolicy.providerNames.length === 0) {
+        return providers;
+    }
+
+    const allowedProviders = new Set(routePolicy.providerNames);
+
+    return providers.filter(provider => allowedProviders.has(provider.name));
+}

--- a/src/origin/originFallback.js
+++ b/src/origin/originFallback.js
@@ -1,0 +1,51 @@
+export function createOriginFallbackResponse(request, routePolicy, providers, statusCode = 200) {
+    const url = new URL(request.url);
+    const assetPath = url.pathname + url.search;
+
+    return Response.json({
+        protocol: "mgp-origin-fallback-v1",
+        status: "origin-fallback-allowed",
+        statusCode: statusCode,
+        routePolicyId: routePolicy.id,
+        routeKey: routePolicy.routeKey,
+        assetPath: assetPath,
+        providersTried: providers.map(provider => provider.name),
+        generatedAt: Date.now()
+    }, {
+        status: statusCode,
+        headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+            "x-flareless-route": "origin-fallback",
+            "x-flareless-policy-id": routePolicy.id,
+            "x-flareless-route-key": routePolicy.routeKey
+        }
+    });
+}
+
+export function createFallbackBlockedResponse(request, routePolicy, providers, statusCode = 503) {
+    const url = new URL(request.url);
+    const assetPath = url.pathname + url.search;
+
+    return Response.json({
+        protocol: "mgp-route-policy-v1",
+        status: "fallback-blocked-by-policy",
+        statusCode: statusCode,
+        routePolicyId: routePolicy.id,
+        routeKey: routePolicy.routeKey,
+        assetPath: assetPath,
+        allowPeerFallback: routePolicy.allowPeerFallback,
+        allowOriginFallback: routePolicy.allowOriginFallback,
+        providersTried: providers.map(provider => provider.name),
+        generatedAt: Date.now()
+    }, {
+        status: statusCode,
+        headers: {
+            "content-type": "application/json",
+            "cache-control": "no-store",
+            "x-flareless-route": "fallback-blocked",
+            "x-flareless-policy-id": routePolicy.id,
+            "x-flareless-route-key": routePolicy.routeKey
+        }
+    });
+}

--- a/src/peer/peerFallback.js
+++ b/src/peer/peerFallback.js
@@ -1,4 +1,4 @@
-export function createPeerFallbackResponse(request, providers, statusCode) {
+export function createPeerFallbackResponse(request, providers, statusCode, routePolicy = null) {
     const url = new URL(request.url);
     const assetPath = url.pathname + url.search;
 
@@ -6,17 +6,15 @@ export function createPeerFallbackResponse(request, providers, statusCode) {
         protocol: "mgp-peer-fallback-v1",
         status: "cdn-routes-unavailable",
         statusCode: statusCode || 503,
+        routePolicyId: routePolicy?.id || null,
+        routeKey: routePolicy?.routeKey || null,
         assetPath: assetPath,
         peerLookup: createPeerLookupUrl(url),
         providersTried: providers.map(provider => provider.name),
         generatedAt: Date.now()
     }, {
         status: statusCode || 503,
-        headers: {
-            "content-type": "application/json",
-            "cache-control": "no-store",
-            "x-open-edge-route": "peer-fallback"
-        }
+        headers: createHeaders(routePolicy)
     });
 }
 
@@ -24,4 +22,20 @@ function createPeerLookupUrl(url) {
     const lookup = new URL(url.origin + "/peer/lookup");
     lookup.searchParams.set("chunk", url.pathname);
     return lookup.toString();
+}
+
+function createHeaders(routePolicy) {
+    const headers = {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+        "x-open-edge-route": "peer-fallback",
+        "x-flareless-route": "peer-fallback"
+    };
+
+    if (routePolicy !== null) {
+        headers["x-flareless-policy-id"] = routePolicy.id;
+        headers["x-flareless-route-key"] = routePolicy.routeKey;
+    }
+
+    return headers;
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,10 +1,12 @@
 import { PROVIDERS } from "./config/providers.js";
+import { applyRoutePolicyToProviders, resolveRoutePolicy } from "./config/routePolicies.js";
 import { createMgpManifest, createMgpProviderSnapshot, createMgpRoutePacket } from "./mgp/protocol.js";
 import { selectProviders } from "./routing/selector.js";
 import { fetchThroughProvider } from "./routing/providerFetch.js";
 import { getHealthSnapshot, getLayeredHealthSnapshot, markProviderFailure, markProviderSuccess } from "./routing/health.js";
 import { createHealthLayers, createRouteScope } from "./routing/routeScope.js";
 import { createPeerFallbackResponse } from "./peer/peerFallback.js";
+import { createFallbackBlockedResponse, createOriginFallbackResponse } from "./origin/originFallback.js";
 import { resolveSignalRoomName, createRoomInfo } from "./peer/roomPartition.js";
 import { MgpSignalRoom } from "./peer/signalingObject.js";
 
@@ -40,21 +42,17 @@ export default {
             return Response.json(createMgpManifest(assetPath, PROVIDERS), { headers: secureHeaders() });
         }
 
-        const routeResult = await routeRequest(request);
-
-        if (routeResult !== null) {
-            return routeResult;
-        }
-
-        return createPeerFallbackResponse(request, PROVIDERS, 503);
+        return await routeRequest(request);
     }
 };
 
 async function routeRequest(request) {
     const startedAt = Date.now();
     const routeScope = createRouteScope(request);
+    const routePolicy = resolveRoutePolicy(routeScope);
+    const candidateProviders = applyRoutePolicyToProviders(PROVIDERS, routePolicy);
     const healthLayers = createHealthLayers(routeScope);
-    const rankedProviders = selectProviders(PROVIDERS, getLayeredHealthSnapshot(healthLayers));
+    const rankedProviders = selectProviders(candidateProviders, getLayeredHealthSnapshot(healthLayers));
     const routePacket = createMgpRoutePacket(request, rankedProviders, routeScope);
     const attempts = [];
 
@@ -94,6 +92,7 @@ async function routeRequest(request) {
         headers.set("x-flareless-route-id", routePacket.requestId);
         headers.set("x-flareless-route-key", routePacket.routeKey);
         headers.set("x-flareless-request-id", routePacket.requestId);
+        headers.set("x-flareless-policy-id", routePolicy.id);
         headers.set("x-flareless-reason", createRouteReason(attempts));
         headers.set("x-flareless-attempts", createAttemptHeader(attempts));
 
@@ -105,7 +104,15 @@ async function routeRequest(request) {
         });
     }
 
-    return null;
+    if (routePolicy.allowPeerFallback === true) {
+        return createPeerFallbackResponse(request, rankedProviders, 503, routePolicy);
+    }
+
+    if (routePolicy.allowOriginFallback === true) {
+        return createOriginFallbackResponse(request, routePolicy, rankedProviders, 200);
+    }
+
+    return createFallbackBlockedResponse(request, routePolicy, rankedProviders, 503);
 }
 
 function markProviderFailureForScopes(routeScope, providerName, reason) {

--- a/tests/worker-routes.test.mjs
+++ b/tests/worker-routes.test.mjs
@@ -93,6 +93,7 @@ test("successful CDN route returns provider headers", async () => {
         assert.equal(response.headers.get("x-open-edge-provider"), "cdn-a");
         assert.ok(response.headers.get("x-mgp-route-id"));
         assert.equal(response.headers.get("x-flareless-provider"), "cdn-a");
+        assert.equal(response.headers.get("x-flareless-policy-id"), "video-public-peer-first");
         assert.equal(response.headers.get("x-flareless-route-key"), "route:/video");
         assert.ok(response.headers.get("x-flareless-request-id"));
         assert.equal(response.headers.get("x-flareless-reason"), "PRIMARY_PROVIDER_SUCCESS");
@@ -186,6 +187,73 @@ test("route scoped health keeps unrelated routes on primary provider", async () 
         assert.equal(unrelatedRouteResponse.headers.get("x-flareless-provider"), "cdn-a");
         assert.equal(unrelatedRouteResponse.headers.get("x-flareless-route-key"), "route:/assets");
         assert.equal(unrelatedRouteUrls[0], "https://cdn-a.example.com/assets/logo.png");
+    } finally {
+        globalThis.fetch = oldFetch;
+    }
+});
+
+test("video route policy allows peer fallback after all providers fail", async () => {
+    const oldFetch = globalThis.fetch;
+
+    globalThis.fetch = async function() {
+        return new Response("unavailable", { status: 503 });
+    };
+
+    try {
+        const response = await worker.fetch(jsonRequest("/video/policy-test/v1/chunk-0001.m4s"), makeEnv(), {});
+        const body = await response.json();
+
+        assert.equal(response.status, 503);
+        assert.equal(response.headers.get("x-flareless-route"), "peer-fallback");
+        assert.equal(response.headers.get("x-flareless-policy-id"), "video-public-peer-first");
+        assert.equal(body.protocol, "mgp-peer-fallback-v1");
+        assert.equal(body.routePolicyId, "video-public-peer-first");
+        assert.equal(body.routeKey, "route:/video/policy-test/v1");
+    } finally {
+        globalThis.fetch = oldFetch;
+    }
+});
+
+test("origin allowed route policy returns origin fallback when providers fail", async () => {
+    const oldFetch = globalThis.fetch;
+
+    globalThis.fetch = async function() {
+        return new Response("unavailable", { status: 503 });
+    };
+
+    try {
+        const response = await worker.fetch(jsonRequest("/origin-allowed/file.bin"), makeEnv(), {});
+        const body = await response.json();
+
+        assert.equal(response.status, 200);
+        assert.equal(response.headers.get("x-flareless-route"), "origin-fallback");
+        assert.equal(response.headers.get("x-flareless-policy-id"), "origin-fallback-allowed");
+        assert.equal(body.protocol, "mgp-origin-fallback-v1");
+        assert.equal(body.routePolicyId, "origin-fallback-allowed");
+        assert.equal(body.routeKey, "route:/origin-allowed");
+    } finally {
+        globalThis.fetch = oldFetch;
+    }
+});
+
+test("private route policy blocks peer and origin fallback", async () => {
+    const oldFetch = globalThis.fetch;
+
+    globalThis.fetch = async function() {
+        return new Response("unavailable", { status: 503 });
+    };
+
+    try {
+        const response = await worker.fetch(jsonRequest("/private/locked.bin"), makeEnv(), {});
+        const body = await response.json();
+
+        assert.equal(response.status, 503);
+        assert.equal(response.headers.get("x-flareless-route"), "fallback-blocked");
+        assert.equal(response.headers.get("x-flareless-policy-id"), "private-no-fallback");
+        assert.equal(body.protocol, "mgp-route-policy-v1");
+        assert.equal(body.status, "fallback-blocked-by-policy");
+        assert.equal(body.allowPeerFallback, false);
+        assert.equal(body.allowOriginFallback, false);
     } finally {
         globalThis.fetch = oldFetch;
     }


### PR DESCRIPTION
## Summary

Adds explicit route policy objects so fallback behavior is controlled per route instead of being implied by the worker fallback path.

## What changed

- Added `src/config/routePolicies.js` with route policy objects for video, private, origin allowed, and default public static routes.
- Added route policy resolution and provider filtering helpers.
- Added `src/origin/originFallback.js` for explicit origin fallback and blocked fallback responses.
- Updated peer fallback responses to include policy id and route key.
- Updated worker routing so all provider failure now follows the resolved route policy:
  - peer fallback if allowed
  - origin fallback if allowed
  - blocked response if neither fallback is allowed
- Added tests proving peer allowed, origin allowed, and fallback blocked policy outcomes.

## Validation

New tests cover:

1. `/video/...` allows peer fallback after all providers fail.
2. `/origin-allowed/...` returns origin fallback after all providers fail.
3. `/private/...` blocks both peer and origin fallback.

This makes route behavior explicit and keeps route independence aligned with route policy.